### PR TITLE
Fix non-determinism by using LinkedHashTest for ordered element iteration

### DIFF
--- a/src/test/java/vjson/TestInterpreterSamplePrograms.java
+++ b/src/test/java/vjson/TestInterpreterSamplePrograms.java
@@ -308,7 +308,7 @@ public class TestInterpreterSamplePrograms {
         String prog = "{\n" +
             "// List, Set and Map\n" +
             "let StringList = { std.List:[ string ] }\n" +
-            "let IntSet = { std.Set:[ int ] }\n" +
+            "let IntSet = { std.LinkedHashSet:[ int ] }\n" +
             "// std.LinkedHashSet is also available\n" +
             "let StringIntMap = { std.LinkedHashMap:[ string, int ] }\n" +
             "// std.Map is also available\n" +


### PR DESCRIPTION
### Description
The PR fixes the following test which could produce non-deterministic result
`vjson.TestInterpreterSamplePrograms.collections`

### Setup:
Java version: 11.0.20.1
Maven version: 3.6.3


### Test failure reproduction:
The [test](https://github.com/wkgcass/vjson/blob/436a655efa6a86cca8f96f43375db3b2c25373dc/src/test/java/vjson/TestInterpreterSamplePrograms.java#L307)  compares a set of items with Hardcoded values. However, the order of key value pairs within hashset is not gauranteed. Hence the test can fail. This issue was verified using the [NonDex plugin](https://github.com/TestingResearchIllinois/NonDex).

### Steps
```
1. git clone https://github.com/wkgcass/vjson.git
2. cd vjson
3. Add Nondex Plugin in `build.gradle.kts` dependencies
dependencies {
    classpath("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
    classpath("io.vproxy:vjson:1.3.3")
    classpath("edu.illinois:plugin:2.1.1")
  }
4. Apply the plugin 
apply(plugin="edu.illinois.nondex")
```
5. Run the test utilizing the plugin
`./gradlew --info nondexTest --tests TestInterpreterSamplePrograms.collections`

### Error Log
Test failure in Nondex Mode
```
vjson.TestInterpreterSamplePrograms > collections FAILED
    java.lang.AssertionError: expected:<[list = [hello, world], set = [1, 2], map = {alice=1, bob=2, eve=3}, hello, world, alice, bob, eve]> but was:<[list = [hello, world], set = [2, 1], map = {alice=1, bob=2, eve=3}, hello, world, alice, bob, eve]>
        at org.junit.Assert.fail(Assert.java:88)
        at org.junit.Assert.failNotEquals(Assert.java:834)
        at org.junit.Assert.assertEquals(Assert.java:118)
        at org.junit.Assert.assertEquals(Assert.java:144)
        at vjson.TestInterpreterSamplePrograms.collections(TestInterpreterSamplePrograms.java:355)
```
The above error occurs when comparing the contents of set with hardcoded values since Hashset does not maintain the order of contents. 

### Fix
The Non-determinism can be fixed by utilizing a LinkedHashset, which maintains the order of contents. Hence, making the test deterministic.

### Verification
Verified the fix by running by Nondex and ensuring that the test passes with multiple runs